### PR TITLE
Changed the cry emoji picker to a fox

### DIFF
--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.js
@@ -356,8 +356,8 @@ export default class EmojiPickerDropdown extends React.PureComponent {
         <div ref={this.setTargetRef} className='emoji-button' title={title} aria-label={title} aria-expanded={active} role='button' onClick={this.onToggle} onKeyDown={this.onToggle} tabIndex={0}>
           <img
             className={classNames('emojione', { 'pulse-loading': active && loading })}
-            alt='🙂'
-            src={`${assetHost}/emoji/1f602.svg`}
+            alt='🦊'
+            src={`${assetHost}/emoji/1f98a.svg`}
           />
         </div>
 


### PR DESCRIPTION
Just that. Code is changed in the same fashion, I did on my instance.
The file /public/emoji/1f98a.svg can be exchanged to make it a purple
fox or the changed line can be pointed to a sky emoji (needs to be in svg format).